### PR TITLE
Detect 32/64 lib of GLCD_SDK

### DIFF
--- a/specelG13Handler.py
+++ b/specelG13Handler.py
@@ -1,8 +1,10 @@
 #!python3
+from platform import architecture
+from sys import maxsize
 
 import GLCD_SDK
 from PIL import Image, ImageFont, ImageDraw
-from ctypes import c_ubyte
+from ctypes import c_ubyte, sizeof, c_voidp
 import socket
 from specelFA18Handler import FA18Handler
 from specelF16Handler import F16Handler
@@ -27,7 +29,8 @@ class G13Handler:
 		self.height=43
 
 		#GLCD Init
-		GLCD_SDK.initDLL("C:\\Program Files\\Logitech Gaming Software\\LCDSDK_8.57.148\\Lib\\GameEnginesWrapper\\x86\\LogitechLcdEnginesWrapper.dll")
+		arch = 'x64' if all([architecture()[0] == '64bit', maxsize > 2 ** 32, sizeof(c_voidp) > 4]) else 'x86'
+		GLCD_SDK.initDLL("C:\\Program Files\\Logitech Gaming Software\\LCDSDK_8.57.148\\Lib\\GameEnginesWrapper\\{}\\LogitechLcdEnginesWrapper.dll".format(arch))
 		GLCD_SDK.LogiLcdInit("Python",GLCD_SDK.TYPE_MONO)
 
 		self.img = Image.new('1',(self.width,self.height),0)


### PR DESCRIPTION
Base on discussion here: [detect if python is running as 64bit](https://stackoverflow.com/questions/1842544/how-do-i-detect-if-python-is-running-as-a-64-bit-application)

I use **64bit** python and now **32bit** is hard-coded. Anyway it is easy to detected.